### PR TITLE
Fix TypeScript capitalization in fastly.toml

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -5,7 +5,7 @@ authors = ["<oss@fastly.com>"]
 description = "A basic starter kit that demonstrates routing, simple synthetic responses and overriding caching rules."
 language = "javascript"
 manifest_version = 2
-name = "Default starter for Typescript"
+name = "Default starter for TypeScript"
 
 [scripts]
   build = "npm run build"


### PR DESCRIPTION
This PR fixes a minor capitalization issue in the fastly.toml file, which I assume affects the title of [the DevHub page](https://developer.fastly.com/solutions/starters/compute-starter-kit-typescript/).