### PR TITLE
Fix immediate init error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "lib": [ "es2022" ],
     "rootDir": "src",
-    "outDir": "build"
+    "outDir": "build",
+    "skipLibCheck": true
   },
   "include": [
     "./src/**/*.js",


### PR DESCRIPTION
When initialising a new project using the typescript setup, the project immediately errors on prebuild with 

```
../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:523:15 - error TS2300: Duplicate identifier 'URL'.

523 declare class URL {
                  ~~~

  ../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/url.d.ts:898:19
    898         interface URL extends _URL {}
                          ~~~
    'URL' was also declared here.
  ../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/url.d.ts:908:13
    908         var URL: typeof globalThis extends {
                    ~~~
    and here.

../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:571:15 - error TS2300: Duplicate identifier 'URLSearchParams'.

571 declare class URLSearchParams {
                  ~~~~~~~~~~~~~~~

  ../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/url.d.ts:897:19
    897         interface URLSearchParams extends _URLSearchParams {}
                          ~~~~~~~~~~~~~~~
    'URLSearchParams' was also declared here.
  ../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/url.d.ts:918:13
    918         var URLSearchParams: typeof globalThis extends {
                    ~~~~~~~~~~~~~~~
    and here.

../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:658:15 - error TS2300: Duplicate identifier 'TextEncoder'.

658 declare class TextEncoder {
                  ~~~~~~~~~~~

  ../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/util.d.ts:1283:13
    1283         var TextEncoder: typeof globalThis extends {
                     ~~~~~~~~~~~
    'TextEncoder' was also declared here.

../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:704:15 - error TS2300: Duplicate identifier 'TextDecoder'.

704 declare class TextDecoder {
                  ~~~~~~~~~~~

  ../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/util.d.ts:1273:13
    1273         var TextDecoder: typeof globalThis extends {
                     ~~~~~~~~~~~
    'TextDecoder' was also declared here.

../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/url.d.ts:897:19 - error TS2300: Duplicate identifier 'URLSearchParams'.

897         interface URLSearchParams extends _URLSearchParams {}
                      ~~~~~~~~~~~~~~~

  ../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:571:15
    571 declare class URLSearchParams {
                      ~~~~~~~~~~~~~~~
    'URLSearchParams' was also declared here.

../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/url.d.ts:898:19 - error TS2300: Duplicate identifier 'URL'.

898         interface URL extends _URL {}
                      ~~~

  ../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:523:15
    523 declare class URL {
                      ~~~
    'URL' was also declared here.

../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/url.d.ts:908:13 - error TS2300: Duplicate identifier 'URL'.

908         var URL: typeof globalThis extends {
                ~~~

  ../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:523:15
    523 declare class URL {
                      ~~~
    'URL' was also declared here.

../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/url.d.ts:918:13 - error TS2300: Duplicate identifier 'URLSearchParams'.

918         var URLSearchParams: typeof globalThis extends {
                ~~~~~~~~~~~~~~~

  ../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:571:15
    571 declare class URLSearchParams {
                      ~~~~~~~~~~~~~~~
    'URLSearchParams' was also declared here.

../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/util.d.ts:1273:13 - error TS2300: Duplicate identifier 'TextDecoder'.

1273         var TextDecoder: typeof globalThis extends {
                 ~~~~~~~~~~~

  ../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:704:15
    704 declare class TextDecoder {
                      ~~~~~~~~~~~
    'TextDecoder' was also declared here.

../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/util.d.ts:1283:13 - error TS2300: Duplicate identifier 'TextEncoder'.

1283         var TextEncoder: typeof globalThis extends {
                 ~~~~~~~~~~~

  ../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:658:15
    658 declare class TextEncoder {
                      ~~~~~~~~~~~
    'TextEncoder' was also declared here.


Found 10 errors in 3 files.

Errors  Files
     4  ../../../node_modules/.pnpm/@fastly+js-compute@3.6.0/node_modules/@fastly/js-compute/types/globals.d.ts:523
     4  ../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/url.d.ts:897
     2  ../../../node_modules/.pnpm/@types+node@20.7.0/node_modules/@types/node/util.d.ts:1273
```

adding skipLibCheck resolves this error.

Issues are disabled for this repository with no indication of alternative methods of reporting issues, so a direct fix was the only solution available.